### PR TITLE
DX: stop using legacy vendor name of php-coveralls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",
-    "satooshi/php-coveralls": "^1.0"
+    "php-coveralls/php-coveralls": "^1.0.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
if possible, we can update to v2, but I don't know what is min PHP version of all packages using this config