### PR TITLE
Exclude filesystem functions from forced namespacing

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -25,7 +25,7 @@ class Config extends PhpCsFixerConfig
             "cast_spaces" => true,
             "combine_consecutive_unsets" => true,
             "function_to_constant" => true,
-            "native_function_invocation" => true,
+            "native_function_invocation" => ['exclude' => ['touch', 'link', 'symlink', 'readlink', 'rename', 'unlink', 'mkdir', 'rmdir', 'scandir', 'chmod', 'chown', 'lstat', 'mtime', 'atime', 'ctime']],
             "no_multiline_whitespace_before_semicolons" => true,
             "no_unused_imports" => true,
             "no_useless_else" => true,


### PR DESCRIPTION
This allows usage of amphp/file's filesystem functions without having to change back function calls from `\function` to `function` every time after calling php-cs-fixer.