### PR TITLE
Add `nullable_type_declaration_for_default_null_value` to the default rules

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -57,6 +57,7 @@ class Config extends PhpCsFixerConfig
             "psr_autoloading" => ['dir' => $this->src],
             "return_type_declaration" => ["space_before" => "none"],
             "short_scalar_cast" => true,
+            "nullable_type_declaration_for_default_null_value" => true,
         ];
     }
 }


### PR DESCRIPTION
This is required to be deprecation free in PHP 8.4, so all AMPHP packages can benefit from this 🙂 

Somehow related to https://github.com/symfony/symfony/issues/54180